### PR TITLE
add bert wsd baseline

### DIFF
--- a/tasks/wsd.py
+++ b/tasks/wsd.py
@@ -60,3 +60,20 @@ def w2v_lesk_ranking(sent, definition_df, wemb_model):
     definition_df["w2v_lesk_ranking"] = definition_df.apply(lambda row: w2v_lesk_wsd(sent, row["nlp_definition"], wemb_model), axis=1)
     results = definition_df.set_index('sense_id').to_dict()["w2v_lesk_ranking"]
     return results
+
+
+### ---------------------------------------------------
+### BERT Lesk WSD baseline
+    
+def bert_lesk_wsd(sent1, sent2, bert_sentsim_model):
+    
+    sent1_embedding = bert_sentsim_model.encode([sent1]) # Full sentence
+    sent2_embedding = bert_sentsim_model.encode([sent2]) # Full sentence
+    
+    sim = 1.0 - scipy.spatial.distance.cdist(sent1_embedding, sent2_embedding, "cosine")[0][0]
+    return sim
+
+def bert_lesk_ranking(sent, definition_df, bert_sentsim_model):
+    definition_df["bert_lesk_ranking"] = definition_df.apply(lambda row: bert_lesk_wsd(sent, row["definition"], bert_sentsim_model), axis=1)
+    results = definition_df.set_index('sense_id').to_dict()["bert_lesk_ranking"]
+    return results

--- a/wsd_experiments.ipynb
+++ b/wsd_experiments.ipynb
@@ -12,6 +12,7 @@
     "from utils import nlp_tools\n",
     "from tqdm.auto import tqdm\n",
     "from gensim.models import Word2Vec\n",
+    "from sentence_transformers import SentenceTransformer\n",
     "\n",
     "tqdm.pandas()\n",
     "\n",
@@ -111,6 +112,22 @@
     "# Warning: I use a Word2vec model trained on all 19thC BL corpus that is locally stored.\n",
     "wemb_model = Word2Vec.load(\"models/w2v/w2v_v004/w2v_words.model\")\n",
     "machine_df[approach] = machine_df.progress_apply (lambda row: wsd.w2v_lesk_ranking(row[\"nlp_full_text\"], definition_df, wemb_model), axis=1)\n",
+    "\n",
+    "wsd.eval(machine_df[approach],machine_df[\"sense_id\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "approach = \"bert_lesk_ranking\"\n",
+    "\n",
+    "# Download model from (warning: this is a contemporary model):\n",
+    "# https://public.ukp.informatik.tu-darmstadt.de/reimers/sentence-transformers/v0.2/bert-base-nli-mean-tokens.zip\n",
+    "bert_sentsim_model = SentenceTransformer('models/bert/bert-base-nli-mean-tokens')\n",
+    "machine_df[approach] = machine_df.progress_apply (lambda row: wsd.bert_lesk_ranking(row[\"text\"][\"full_text\"], definition_df, bert_sentsim_model), axis=1)\n",
     "\n",
     "wsd.eval(machine_df[approach],machine_df[\"sense_id\"])"
    ]


### PR DESCRIPTION
I have just added the other unsupervised baseline, using `bert`.

The model can be downloaded from [here](https://public.ukp.informatik.tu-darmstadt.de/reimers/sentence-transformers/v0.2/bert-base-nli-mean-tokens.zip). I have it locally stored under `HistoricalDictionaryExpansion/models/bert/` at the moment.